### PR TITLE
Running on windows

### DIFF
--- a/.idea/runConfigurations/Main.xml
+++ b/.idea/runConfigurations/Main.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Main" type="CMakeRunConfiguration" factoryName="Application" WORKING_DIR="" PASS_PARENT_ENVS="FALSE" PROJECT_NAME="Main" TARGET_NAME="Main" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Main" RUN_TARGET_NAME="Main">
+  <configuration default="false" name="Main" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="./address.txt" WORKING_DIR="file://$PROJECT_DIR$" PASS_PARENT_ENVS="FALSE" PROJECT_NAME="Main" TARGET_NAME="Main" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Main" RUN_TARGET_NAME="Main">
     <envs />
     <method />
   </configuration>

--- a/.idea/runConfigurations/Main.xml
+++ b/.idea/runConfigurations/Main.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Main" type="CMakeRunConfiguration" factoryName="Application" WORKING_DIR="" PASS_PARENT_ENVS="FALSE" PROJECT_NAME="Main" TARGET_NAME="Main" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Main" RUN_TARGET_NAME="Main">
+    <envs />
+    <method />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
 cmake_minimum_required (VERSION 3.3)
 project (Main)
 add_executable(Main main.cpp)
+
+SET(GCC_DEBUG_COMPILE_FLAGS "-Werror")
+SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_DEBUG_COMPILE_FLAGS}" )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.3)
 project (Main)
-add_executable(Main main.cpp)
+add_executable(Main main.cpp cache.cpp hash_functions.cpp replacement_policies.cpp)
 
 SET(GCC_DEBUG_COMPILE_FLAGS "-Werror")
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_DEBUG_COMPILE_FLAGS}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required (VERSION 3.3)
+project (Main)
+add_executable(Main main.cpp)

--- a/cache.h
+++ b/cache.h
@@ -11,37 +11,45 @@
 #include <iomanip>	
 
 #include "defaults.h"
+#include "types.h"
 
 using namespace std;
 
-typedef struct cache_line_ {
+struct CacheLine {
 	uint tag;
 	bool valid;
 	bool dirty;
 	int number_data_blocks; //in B
-} cache_line;
+};
 
-typedef struct cache_statistics_ {
+struct CacheStatistics {
 	uint hits;
 	uint misses;
 	uint access; //total memory references 
 	uint replacements; //total number of cache line replacements
 	uint write_backs; //total number of write backs
 	double bandwidth;
-} cache_statistics;
+};
 
-typedef vector <cache_line> cache_lines;
+/**
+ * CacheLines is a collection of CacheLine objects, held in a vector.
+ */
+typedef vector<CacheLine> CacheLines;
 
-class cache {
+
+/**
+ * Describes a cache
+ */
+class Cache {
 	
 	public: 
 		/*Default Constructor*/
-		cache(uint in_size=CACHE_SIZE, int in_associativity=ASSOCIATIVITY, int in_banks=BANKS, 
+		Cache(uint in_size=CACHE_SIZE, int in_associativity=ASSOCIATIVITY, int in_banks=BANKS,
 			int in_number_cache_lines=NUMBER_CACHE_LINES, int in_number_data_blocks=NUMBER_DATA_BLOCKS, 
-			int in_replacement_policy=REPLACEMENT_POLICY);
+			ReplacementPolicy in_replacement_policy=REPLACEMENT_POLICY);
 		
 		/*Default Destructor*/
-		~cache();
+		~Cache();
 
 		/*Reinitialize cache usually after a program is complete*/
 		void reinit_cache();
@@ -63,7 +71,7 @@ class cache {
 		bool run(istream& stream, int lines=-1); //run cache from stream.. can do cin as well
 
 		/*Set Virtual bank id and line in the bank to be replaced based on the replacement policy*/
-		int get_replacement_line( cache_lines replacement_lines );
+		int get_replacement_line( CacheLines replacement_lines );
 
 		/*In case a line in the set needs to be replaced */
 		//int implement_replacement_policy(int index, int max_index, int policy_number); 
@@ -77,11 +85,11 @@ class cache {
 		int number_cache_sets;
 		int number_data_blocks; //per cache line
 		//vector <cache_line> cache_lines;
-		vector <cache_lines> virtual_banks; //bank = collection of cache lines that belong to different sets
-		cache_statistics stats; 
-		cache *lower_level;	
-		cache *upper_level; 
-		int replacement_policy;
+		vector<CacheLines> virtual_banks; //bank = collection of cache lines that belong to different sets
+		CacheStatistics stats;
+		Cache *lower_level;
+    Cache *upper_level;
+		ReplacementPolicy replacement_policy;
 		/*need hash functions for associativity later*/ 
 };
 

--- a/defaults.h
+++ b/defaults.h
@@ -3,7 +3,10 @@
 */
 
 #include <map>
-#include <string>	
+#include <string>
+#include "types.h"
+
+
 
 const uint CACHE_SIZE = 65536; //64KB => tag=32-10-8=14
 const int ASSOCIATIVITY = 2; //Direct Mapped=1, Fully Associative=0
@@ -11,9 +14,5 @@ const int ASSOCIATIVITY = 2; //Direct Mapped=1, Fully Associative=0
 const int BANKS = 1;
 const int NUMBER_CACHE_LINES = 1024; //1024 lines => 10 bits
 const int NUMBER_DATA_BLOCKS = 64; //Data Block = 64 bytes => 8 bits
-const int REPLACEMENT_POLICY = 0; //random=0
+const ReplacementPolicy REPLACEMENT_POLICY = RANDOM ; //random=0
 
-const std::map < std::string, int > r_policies_map = {
-	{"random", 0},
-	{"fifo", 1}
-};

--- a/hash_functions.h
+++ b/hash_functions.h
@@ -7,6 +7,8 @@
 
 #include <iostream>
 
+#include "types.h"
+
 /*Return which cache line to access for each virtual bank -- just a mod function for set associative*/	
 int hash_address(uint index, int virtual_bank_id, int number_cache_sets, bool set_associative);
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,15 +8,16 @@ Run: ./cache address_file #lines
 
 #include "cache.h"
 #include <fstream>
+#include <stdlib.h>
 
 int main(int argc, char ** argv) {
-	cache default_cache = cache();
+	Cache default_cache = Cache();
 	ifstream input_file(argv[1]);
 	if (! input_file.is_open()) {
 		cout << "\nError... Cannot open address file!!!" <<endl;
 	}
 	else {
-		int lines = atoi(argv[2]);
+		long lines = strtoul(argv[2], NULL, 0);
 		default_cache.run(input_file, lines); //Run the 1st lines addresses in input_file on the cache, 0=complete run
 		input_file.close();
 		default_cache.dump_stats(cout);

--- a/replacement_policies.cpp
+++ b/replacement_policies.cpp
@@ -4,7 +4,7 @@
 
 #include "replacement_policies.h"
 
-int cache::get_replacement_line( cache_lines replacement_lines ) {
+int Cache::get_replacement_line(CacheLines replacement_lines ) {
 	
 	int return_bank_id = 0;
 
@@ -50,7 +50,7 @@ int cache::implement_replacement_policy(int index, int max_index, int policy_num
 	return return_cache_line;
 }*/
 
-int implement_replacement_policy (cache_lines replacement_lines, int policy_number) {
+int implement_replacement_policy (CacheLines replacement_lines, int policy_number) {
 	srand(time(0));
 	int return_bank_id = -1;
 	int number_banks = replacement_lines.size();

--- a/replacement_policies.h
+++ b/replacement_policies.h
@@ -10,6 +10,6 @@
 #include <stdlib.h>
 
 /*Helper function to implement replacement policy*/
-int implement_replacement_policy (cache_lines replacement_lines, int policy_number);
+int implement_replacement_policy (CacheLines replacement_lines, int policy_number);
 
 #endif

--- a/types.h
+++ b/types.h
@@ -1,0 +1,15 @@
+//
+// Created by ryanl on 03/02/16.
+//
+
+#ifndef MAIN_TYPES_H
+#define MAIN_TYPES_H
+
+typedef unsigned int uint;
+
+enum ReplacementPolicy {
+  RANDOM = 0,
+  FIFO = 1,
+};
+
+#endif //MAIN_TYPES_H


### PR DESCRIPTION
1. Got running on Windows using CLion IDE -- forced one small code change (uint typedef)
   Misc system specs: Using CLion IDE -- this system/project was configured using MinGW (installed packages gcc, g++, mingw32-make, mingw32-zlib), the CLion built-in version of CMake (v3.3) and the CLion built-in version of GDB.
2. Did some refactoring of class names to follow google code convention more closely.
3. Refactored a 'map<string, int>' into an enum and put in the types.h file
4. Changed 'atoi' calls to 'strtol'
